### PR TITLE
Fixed bug in Vector2 class

### DIFF
--- a/src/math/Vector2.java
+++ b/src/math/Vector2.java
@@ -226,7 +226,7 @@ public class Vector2 {
 	 * @return The dot product.
 	 */
 	public float dot(Vector2 v) {
-		return x*v.getX()+y*getY();
+		return x*v.getX()+y*v.getY();
 	}
 	
 	/**


### PR DESCRIPTION
The Vector2 class had a small bug in it's dot(Vector2 v) method.
